### PR TITLE
The major change being that we always use __getattr__ instead of __getattribute__

### DIFF
--- a/jpype/__init__.py
+++ b/jpype/__init__.py
@@ -69,4 +69,4 @@ if hasattr(_jpype, 'bootstrap'):
    _jpype.bootstrap()
    _core.initializeResources()
 
-root = _JForward(None)
+jroot = _JForward(None)

--- a/jpype/__init__.py
+++ b/jpype/__init__.py
@@ -17,6 +17,7 @@
 # *****************************************************************************
 import _jpype
 from ._jinit import *
+from ._jforward import JForward as _JForward
 from ._jpackage import *
 from ._jproxy import *
 from ._core import *
@@ -67,3 +68,5 @@ JField = _jpype._JField
 if hasattr(_jpype, 'bootstrap'):
    _jpype.bootstrap()
    _core.initializeResources()
+
+root = _JForward(None)


### PR DESCRIPTION

This makes a much nicer access pattern for ``self._instance`` / ``self._symbol``, but performance should be checked to compare the two. This also fixes the issubclass check, which had the operands in the wrong order.

I also prototyped hooking it into JPype (because I wanted to play with how it would look to implement a library). To do so, I indented your tests.

Fixes the ``issubclass`` failing case (it was simply an order mismatch).

Note: This doesn't need to be merged (feel free to pick off the bits you like/want), I just wanted to play a little with it.